### PR TITLE
Compilation of developer documentation on Read The Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ User documentation can be found on the `wiki
 <https://humgenprojects.lumc.nl/trac/mutalyzer>`_. From there, you can also
 submit bug reports and feature requests.
 
-Developer documentation can be found in the ``doc/`` subdirectory and can be
-compiled to HTML by running ``make html`` from there. This requires `Sphinx`_
-to be installed.
+Developer documentation is `hosted at Read The Docs
+<http://mutalyzer.readthedocs.org>`_. Contributions to Mutalyzer are welcome
+as `GitHub pull requests <https://github.com/LUMC/mutalyzer/pulls>`_.
 
 
 Copyright

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,18 @@
 import sys
 import os
 
+# http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+from mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return Mock()
+
+MOCK_MODULES = ['MySQLdb', 'cchardet', 'lxml', 'lxml.builder', 'lxml.etree',
+                'magic']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,12 @@
+Sphinx
+alembic
+biopython
+flask
+mock
+pyparsing
+redis
+sqlalchemy
+sphinx-rtd-theme
+spyne
+suds
+xlrd


### PR DESCRIPTION
We use a separate `doc/requirements.txt` file for building the
documentation. Since on Read The Docs where we cannot install
packages depending on C libraries, we mock these packages in
`doc/conf.py` and omit them from the requirements.
